### PR TITLE
Exit with code 1 in case of an unhandled promise rejection

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,11 @@ const {
   warn
 } = require('@vue/cli-shared-utils')
 
+process.on('unhandledRejection', (message) => {
+  error(message)
+  process.exit(1)
+})
+
 module.exports = (api, projectOptions) => {
   api.registerCommand('s3-deploy', {
     description: 'Deploys the built assets to an S3 bucket based on options set in vue.config.js.',


### PR DESCRIPTION
Currently, if the process fails for some reason it is not detectable by outside tools as the process exit code is still 0 (graceful termination). This is shown below:

```
> $(npm bin)/vue-cli-service s3-deploy
 WARN  As of v1.3, s3deploy supports .env file variables.
 WARN  Current support for CLI options will be removed in upcoming versions. Please move your settings into .env files.
 WARN  See: https://github.com/multiplegeorges/vue-cli-plugin-s3-deploy#per-environment-options
(node:60480) UnhandledPromiseRejectionWarning: Error: connect EHOSTUNREACH 169.254.169.254:80 - Local (172.16.0.154:49919)
    at Object._errnoException (util.js:1022:11)
    at _exceptionWithHostPort (util.js:1044:20)
    at internalConnect (net.js:976:16)
    at defaultTriggerAsyncIdScope (internal/async_hooks.js:283:19)
    at net.js:1074:9
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickDomainCallback (internal/process/next_tick.js:218:9)
    at Function.Module.runMain (module.js:695:11)
    at startup (bootstrap_node.js:188:16)
    at bootstrap_node.js:609:3
(node:60480) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:60480) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
      'region': 'AWS region for the specified bucket (default: us-east-1)',

> echo $?
0 
```

This PR adds a catch-all for any unhandled promise rejections to make sure that a non-zero exit code is produced for these cases. This allows CI tools to detect the failure. This is also what will be done by default by future Node.js versions, as shown in the deprecation warning message above. You can see the difference here and confirm that the correct exit code is now returned:

```
> npm run deploy

> vue-cli-service s3-deploy

 WARN  As of v1.3, s3deploy supports .env file variables.
 WARN  Current support for CLI options will be removed in upcoming versions. Please move your settings into .env files.
 WARN  See: https://github.com/multiplegeorges/vue-cli-plugin-s3-deploy#per-environment-options
 ERROR  CredentialsError: Missing credentials in config
Error: connect EHOSTUNREACH 169.254.169.254:80 - Local (172.16.0.154:50253)
    at Object._errnoException (util.js:1022:11)
    at _exceptionWithHostPort (util.js:1044:20)
    at internalConnect (net.js:976:16)
    at defaultTriggerAsyncIdScope (internal/async_hooks.js:283:19)
    at net.js:1074:9
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickDomainCallback (internal/process/next_tick.js:218:9)
    at Function.Module.runMain (module.js:695:11)
    at startup (bootstrap_node.js:188:16)
    at bootstrap_node.js:609:3
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! ...@0.1.0 deploy: `vue-cli-service s3-deploy`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the ...@0.1.0 deploy script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     ...

> echo $?
1
```