### PR TITLE
Detect if bucket exists without the need of list all buckets permission

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,11 +23,13 @@ module.exports = (api, projectOptions) => {
       'cloudfrontMatchers': 'A list of paths to invalidate'
     }
   }, (args) => {
-    warn('As of v1.3, s3deploy supports .env file variables.')
-    warn('Current support for CLI options will be removed in upcoming versions. Please move your settings into .env files.')
-    warn('See: https://github.com/multiplegeorges/vue-cli-plugin-s3-deploy#per-environment-options')
-
-    let options = projectOptions.pluginOptions.s3Deploy
+    let options = {};
+    if (projectOptions && projectOptions.pluginOptions && projectOptions.pluginOptions.s3Deploy) {
+      warn('As of v1.3, s3deploy supports .env file variables.')
+      warn('Current support for CLI options will be removed in upcoming versions. Please move your settings into .env files.')
+      warn('See: https://github.com/multiplegeorges/vue-cli-plugin-s3-deploy#per-environment-options')
+      options = projectOptions.pluginOptions.s3Deploy;
+    }
 
     // Check for environmental overrides.
     options.bucket = process.env.VUE_APP_S3D_BUCKET || options.bucket

--- a/s3deploy.js
+++ b/s3deploy.js
@@ -136,12 +136,12 @@ module.exports = async (options, api) => {
 
   async function bucketExists (bucketName) {
     return new Promise((resolve, reject) => {
-      s3.listBuckets((err, data) => {
+      let params = { Bucket: bucketName }
+      s3.headBucket(params, function(err, data) {
         if (err) {
           reject(err)
         } else {
-          let names = data['Buckets'].map(b => b['Name'])
-          resolve(names.includes(bucketName))
+          resolve(true)
         }
       })
     })


### PR DESCRIPTION
* Detect if bucket exists without the need of list all buckets permission (according to the AWS-SDK doc this is the way to check for bucket access: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#headBucket-property)
* Initiate options array if `projectOptions.pluginOptions.s3Deploy` (I added this because the warning says it will be discontinued but if I don't use it, the plugin doesn't work)