### PR TITLE
Support different aws profiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-s3-deploy",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A vue-cli plugin for deploying your built Vue app to an S3 bucket.",
   "keywords": [
     "vue",

--- a/prompts.js
+++ b/prompts.js
@@ -1,4 +1,32 @@
+const fs = require('fs')
+
 module.exports = [
+  {
+    name: 'awsProfile',
+    type: 'list',
+    message: 'How do you want to authenticate with AWS?',
+    default: '0',
+    choices: (_) => {
+      let credentials = fs.readFileSync(require('os').homedir() + '/.aws/credentials', 'utf8');
+      let profileNames = ['Environment variables: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, etc.']
+      let profileNameRegexp = new RegExp(/^\[([0-9a-zA-Z\-]*)\]?/gm)
+
+      match = profileNameRegexp.exec(credentials)
+      while (match != null) {
+        profileNames.push("Profile: " + match[1])
+        match = profileNameRegexp.exec(credentials);
+      }
+
+      return profileNames
+    },
+    filter: (answer) => {
+      if (answer.startsWith('Environment variables:')) {
+        return 'default'
+      } else {
+        return answer.replace('Profile: ', '')
+      }
+    }
+  },
   {
     name: 'region',
     type: 'input',

--- a/prompts.js
+++ b/prompts.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const path = require('path')
 
 module.exports = [
   {
@@ -7,14 +8,19 @@ module.exports = [
     message: 'How do you want to authenticate with AWS?',
     default: '0',
     choices: (_) => {
-      let credentials = fs.readFileSync(require('os').homedir() + '/.aws/credentials', 'utf8');
       let profileNames = ['Environment variables: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, etc.']
-      let profileNameRegexp = new RegExp(/^\[([0-9a-zA-Z\-]*)\]?/gm)
+      let credentialsPath = path.join(require('os').homedir(), '.aws', 'credentials')
 
-      match = profileNameRegexp.exec(credentials)
-      while (match != null) {
-        profileNames.push("Profile: " + match[1])
-        match = profileNameRegexp.exec(credentials);
+      if(fs.existsSync(credentialsPath)) {
+        let credentials = fs.readFileSync(credentialsPath, 'utf8');
+
+        let profileNameRegexp = new RegExp(/^\[([0-9a-zA-Z\-]*)\]?/gm)
+
+        match = profileNameRegexp.exec(credentials)
+        while (match != null) {
+          profileNames.push("Profile: " + match[1])
+          match = profileNameRegexp.exec(credentials);
+        }
       }
 
       return profileNames


### PR DESCRIPTION
This PR adds support for selecting different AWS profiles than the default one in `.aws/credentials`.

It also supports the continued use of environment vars for users that have this plugin as part of a larger pipeline.