### PR TITLE
Deploy from Windows

### DIFF
--- a/s3deploy.js
+++ b/s3deploy.js
@@ -52,8 +52,8 @@ module.exports = async (options, api) => {
 
       let filename = fileList.pop()
       let fileStream = fs.readFileSync(filename)
-      let fileKey = filename.replace(fullAssetPath, '')
-
+      let fileKey = filename.replace(fullAssetPath, '').replace('\\', '/')
+     
       let promise = new Promise((resolve, reject) => {
         let fullFileKey = `${deployPath}${fileKey}`
 


### PR DESCRIPTION
Hi!

There was a bug when you try to deploy from Windows to S3, sometimes the files are not correctly distributed in folders because of the path separator which is `\` on Windows and `/` on Linux. 

This pull request fix this inssue.

Have a good day!