### PR TITLE
fix(cli): exit with status code `1` whenever the deployment fails.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const {
   error,
+  exit,
   warn
 } = require('@vue/cli-shared-utils')
 
@@ -22,7 +23,7 @@ module.exports = (api, configOptions) => {
       error('Configuration is out of date.')
       error(`Config: ${options.pluginVersion} Plugin: ${pluginVersion}`)
       error('Run `vue invoke s3-deploy`')
-      return
+      exit(1)
     }
 
     // Check for environment overrides of the options in vue.config.js.
@@ -62,6 +63,7 @@ module.exports = (api, configOptions) => {
 
     if (!options.bucket) {
       error('Bucket name must be specified with `bucket` in vue.config.js!')
+      exit(1)
     } else {
       if (options.pwa && !options.pwaFiles) {
         warn('Option pwa is set but no files specified! Defaulting to: service-worker.js')

--- a/s3deploy.js
+++ b/s3deploy.js
@@ -246,5 +246,4 @@ module.exports = async (options, api) => {
     error(`${uploadErr.toString()}`)
     exit(1)
   }
-  exit(0)
 }


### PR DESCRIPTION
Closes #47 - It also adds a new error state whenever the number of uploaded files differs from the total files to be uploaded.

I didn't want to refactor a lot because there are no tests and I had to use `link` to test it on my project. If you have any other way to test, let me know.