### PR TITLE
Allow setting Cache-Control on all files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Options are set in `vue.config.js` and overridden on a per-environment basis by 
     enableCloudfront: "Enables support for Cloudfront distribution invalidation (default: false)",
     cloudfrontId: "The ID of the distribution to invalidate",
     cloudfrontMatchers: "A comma-separated list of paths to invalidate (default: /*)",
-    uploadConcurrency: "Number of concurrent uploads (default: 5)"
+    uploadConcurrency: "Number of concurrent uploads (default: 5)",
+    cacheControl: "Sets cache-control metadata for all uploads, overridden for individual files by pwa settings"
 }
 ```
 
@@ -70,6 +71,16 @@ You can specify which files aren't cached by setting a value for the `pwaFiles` 
 ```js
 {
     pwaFiles: "index.html,dont-cache.css,not-this.js"
+}
+```
+
+The `cacheControl` option is intended for deployments with lots of static files and relying on browser or CDN caching.
+
+For example, you may want to have files default to being cached for 1 day:
+
+```js
+{
+    cacheControl: "max-age=86400"
 }
 ```
 
@@ -98,6 +109,8 @@ VUE_APP_S3D_ACL=public-read
 
 VUE_APP_S3D_PWA=true
 VUE_APP_S3D_PWA_FILES=service-worker-stage.js,index.html
+
+VUE_APP_S3D_CACHE_CONTROL="max-age=3600"
 
 VUE_APP_S3D_ENABLE_CLOUDFRONT=true
 VUE_APP_S3D_CLOUDFRONT_ID=AIXXXXXXXX

--- a/index.js
+++ b/index.js
@@ -44,6 +44,8 @@ module.exports = (api, configOptions) => {
     options.pwa = process.env.VUE_APP_S3D_PWA || options.pwa
     options.pwaFiles = process.env.VUE_APP_S3D_PWA_FILES || options.pwaFiles
 
+    options.cacheControl = process.env.VUE_APP_S3D_CACHE_CONTROL || options.cacheControl
+
     options.enableCloudfront = process.env.VUE_APP_S3D_ENABLE_CLOUDFRONT || options.enableCloudfront
     options.cloudfrontId = process.env.VUE_APP_S3D_CLOUDFRONT_ID || options.cloudfrontId
     options.cloudfrontMatchers = process.env.VUE_APP_S3D_CLOUDFRONT_MATCHERS || options.cloudfrontMatchers

--- a/s3deploy.js
+++ b/s3deploy.js
@@ -138,6 +138,10 @@ async function uploadFile (filename, fileBody, options) {
     ContentType: contentTypeFor(fileKey)
   }
 
+  if (options.cacheControl) {
+    uploadParams.CacheControl = options.cacheControl
+  }
+
   if (pwaSupport) {
     uploadParams.CacheControl = 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0'
   }


### PR DESCRIPTION
This commit adds in support for setting a cacheControl option, or
equivalent environment variable, for all files. This will be overridden
by the PWA no-cache settings for any matching PWA files.

Note that the user is not currently prompted to set this value as part
of the initial configuration.