### PR TITLE
Add gzip and cache-control options

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Options are set in `vue.config.js` and overridden on a per-environment basis by 
     enableCloudfront: "Enables support for Cloudfront distribution invalidation (default: false)",
     cloudfrontId: "The ID of the distribution to invalidate",
     cloudfrontMatchers: "A comma-separated list of paths to invalidate (default: /*)",
-    uploadConcurrency: "Number of concurrent uploads (default: 5)"
+    uploadConcurrency: "Number of concurrent uploads (default: 5)",
+    cacheControl: "Sets cache-control metadata for all uploads, overridden for individual files by pwa settings"
 }
 ```
 
@@ -70,6 +71,16 @@ You can specify which files aren't cached by setting a value for the `pwaFiles` 
 ```js
 {
     pwaFiles: "index.html,dont-cache.css,not-this.js"
+}
+```
+
+The `cacheControl` option is intended for deployments with lots of static files and relying on browser or CDN caching.
+
+For example, you may want to have files default to being cached for 1 day:
+
+```js
+{
+    cacheControl: "max-age=86400"
 }
 ```
 
@@ -98,6 +109,8 @@ VUE_APP_S3D_ACL=public-read
 
 VUE_APP_S3D_PWA=true
 VUE_APP_S3D_PWA_FILES=service-worker-stage.js,index.html
+
+VUE_APP_S3D_CACHE_CONTROL="max-age=3600"
 
 VUE_APP_S3D_ENABLE_CLOUDFRONT=true
 VUE_APP_S3D_CLOUDFRONT_ID=AIXXXXXXXX

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Supports:
 * Concurrent uploads for improved deploy times
 * CloudFront distribution invalidation
 * Correct `Cache-Control` metadata for use with PWAs and Service Workers
+* GZIP compression
 * Configurable paths for multiple Vue apps in a single bucket
 
 Prerequisites
@@ -61,6 +62,8 @@ Options are set in `vue.config.js` and overridden on a per-environment basis by 
     cloudfrontMatchers: "A comma-separated list of paths to invalidate (default: /*)",
     uploadConcurrency: "Number of concurrent uploads (default: 5)",
     cacheControl: "Sets cache-control metadata for all uploads, overridden for individual files by pwa settings"
+    gzip: "Enables GZIP compression",
+    gzipFilePattern: "Pattern for matching files to be gzipped. (By default: '**/*.{js,css,json,ico,map,xml,txt,svg,eot,ttf,woff,woff2}')"
 }
 ```
 
@@ -111,6 +114,8 @@ VUE_APP_S3D_PWA=true
 VUE_APP_S3D_PWA_FILES=service-worker-stage.js,index.html
 
 VUE_APP_S3D_CACHE_CONTROL="max-age=3600"
+VUE_APP_S3D_GZIP=true
+VUE_APP_S3D_GZIP_FILE_PATTERN="**/*.{js,css,json,ico,map,xml,txt,svg,eot,ttf,woff,woff2}"
 
 VUE_APP_S3D_ENABLE_CLOUDFRONT=true
 VUE_APP_S3D_CLOUDFRONT_ID=AIXXXXXXXX

--- a/index.js
+++ b/index.js
@@ -47,6 +47,9 @@ module.exports = (api, configOptions) => {
 
     options.cacheControl = process.env.VUE_APP_S3D_CACHE_CONTROL || options.cacheControl
 
+    options.gzip = process.env.VUE_APP_S3D_GZIP || options.gzip
+    options.gzipFilePattern = process.env.VUE_APP_S3D_GZIP_FILE_PATTERN || options.gzipFilePattern
+
     options.enableCloudfront = process.env.VUE_APP_S3D_ENABLE_CLOUDFRONT || options.enableCloudfront
     options.cloudfrontId = process.env.VUE_APP_S3D_CLOUDFRONT_ID || options.cloudfrontId
     options.cloudfrontMatchers = process.env.VUE_APP_S3D_CLOUDFRONT_MATCHERS || options.cloudfrontMatchers

--- a/index.js
+++ b/index.js
@@ -45,6 +45,8 @@ module.exports = (api, configOptions) => {
     options.pwa = process.env.VUE_APP_S3D_PWA || options.pwa
     options.pwaFiles = process.env.VUE_APP_S3D_PWA_FILES || options.pwaFiles
 
+    options.cacheControl = process.env.VUE_APP_S3D_CACHE_CONTROL || options.cacheControl
+
     options.enableCloudfront = process.env.VUE_APP_S3D_ENABLE_CLOUDFRONT || options.enableCloudfront
     options.cloudfrontId = process.env.VUE_APP_S3D_CLOUDFRONT_ID || options.cloudfrontId
     options.cloudfrontMatchers = process.env.VUE_APP_S3D_CLOUDFRONT_MATCHERS || options.cloudfrontMatchers

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "fs-extra": "^7.0.1",
     "globby": "^8.0.1",
     "mime-types": "^2.1.18"
+  },
+  "devDependencies": {
+    "ora": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@vue/cli-shared-utils": "^3.0.0-rc.3",
     "aws-sdk": "^2.225.1",
     "es6-promise-pool": "^2.5.0",
+    "fs-extra": "^7.0.1",
     "globby": "^8.0.1",
     "mime-types": "^2.1.18"
   }

--- a/prompts.js
+++ b/prompts.js
@@ -133,5 +133,24 @@ module.exports = [
     default: '/*',
     when: answers => answers.enableCloudfront === true,
     validate: input => input !== '' ? true : 'At least one invalidation path is required. To invalidate all files, enter /* '
+  },
+  {
+    name: 'cacheControl',
+    type: 'input',
+    message: 'Set cache-control metadata for all uploads.',
+    default: 'max-age=86400'
+  },
+  {
+    name: 'gzip',
+    type: 'confirm',
+    message: 'Enable GZIP compression?',
+    default: false
+  },
+  {
+    name: 'gzipFilePattern',
+    type: 'input',
+    message: 'Files matching this pattern will be gzipped. Note: image files such as .png, .jpg and .gif should not be gzipped.',
+    default: '**/*.{js,css,json,ico,map,xml,txt,svg,eot,ttf,woff,woff2}',
+    when: answers => answers.gzip === true
   }
 ]

--- a/s3deploy.js
+++ b/s3deploy.js
@@ -1,4 +1,4 @@
-const { info, error, logWithSpinner, stopSpinner } = require('@vue/cli-shared-utils')
+const { info, error } = require('@vue/cli-shared-utils')
 const path = require('path')
 const fs = require('fs-extra')
 const mime = require('mime-types')
@@ -6,8 +6,11 @@ const globby = require('globby')
 const AWS = require('aws-sdk')
 const PromisePool = require('es6-promise-pool')
 const zlib = require('zlib');
+const ora = require('ora');
 
 const deployDir = 'dist-deploy';
+
+const spinner = ora();
 
 let S3;
 
@@ -17,8 +20,35 @@ function mimeCharsetsLookup(mimeType, fallback) {
   return (/^text\/|^application\/(javascript|json)/).test(mimeType) ? 'UTF-8' : fallback;
 }
 
-function contentTypeFor (filename) {
+function contentTypeFor(filename) {
   return mime.lookup(filename) || 'application/octet-stream'
+}
+
+async function setupAWS(awsProfile, region) {
+  const awsConfig = {
+    region: region,
+    httpOptions: {
+      connectTimeout: 30 * 1000,
+      timeout: 120 * 1000
+    }
+  }
+
+  if (awsProfile.toString() !== 'default') {
+    const credentials = new AWS.SharedIniFileCredentials({
+      profile: awsProfile
+    })
+
+    await credentials.get((err) => {
+      if (err) {
+        throw new Error(err);
+      }
+
+      awsConfig.credentials = credentials
+    })
+  }
+
+  AWS.config.update(awsConfig)
+  return new AWS.S3()
 }
 
 async function createBucket (options) {
@@ -60,7 +90,7 @@ async function enableStaticHosting (options) {
   // enable static hosting
   try {
     await S3.putBucketWebsite(staticParams).promise()
-    info(`Static Hosting is enabled.`)
+    info('Static Hosting is enabled.')
   } catch (staticErr) {
     error(`Static Hosting could not be enabled on bucket: ${options.bucket}. AWS Error: ${staticErr.toString()}.`)
   }
@@ -104,6 +134,16 @@ function getAllFiles (assetPath, pattern = '**') {
     }));
 }
 
+function parseDeployPath (depPath) {
+  let deployPath = depPath
+  // We don't need a leading slash for root deploys on S3.
+  if (deployPath.startsWith('/')) deployPath = deployPath.slice(1, deployPath.length)
+  // But we do need to make sure there's a trailing one on the path.
+  if (!deployPath.endsWith('/') && deployPath.length > 0) deployPath = deployPath + '/'
+
+  return deployPath
+}
+
 async function invalidateDistribution (options) {
   const cloudfront = new AWS.CloudFront()
   const invalidationItems = options.cloudfrontMatchers.split(',')
@@ -119,23 +159,23 @@ async function invalidateDistribution (options) {
     }
   }
 
-  logWithSpinner(`Invalidating CloudFront distribution: ${options.cloudfrontId}`)
+  spinner.start(`Invalidating CloudFront distribution: ${options.cloudfrontId}`)
 
   try {
     let data = await cloudfront.createInvalidation(params).promise()
+
+    spinner.succeed();
 
     info(`Invalidation ID: ${data['Invalidation']['Id']}`)
     info(`Status: ${data['Invalidation']['Status']}`)
     info(`Call Reference: ${data['Invalidation']['InvalidationBatch']['CallerReference']}`)
     info(`See your AWS console for on-going status on this invalidation.`)
   } catch (err) {
-    error('Cloudfront Error!')
+    spinner.fail('Invalidating CloudFront distrubution failed.');
     error(`Code: ${err.code}`)
     error(`Message: ${err.message}`)
     error(`AWS Request ID: ${err.requestId}`)
   }
-
-  stopSpinner()
 }
 
 async function uploadFile ({ fileKey, fileBody, options, gzip }) {
@@ -167,10 +207,10 @@ async function uploadFile ({ fileKey, fileBody, options, gzip }) {
     uploadParams.CacheControl = 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0'
   }
 
-  console.log('upload', { uploadParams });
-
   try {
+    spinner.start(`Uploading: ${uploadParams.Key}`);
     await S3.upload(uploadParams, options.uploadOptions).promise()
+    spinner.clear();
   } catch (uploadResultErr) {
     // pass full error with details back to promisePool callback
     throw new Error(`(${options.uploadCount}/${options.uploadTotal}) Upload failed: ${fileKey}. AWS Error: ${uploadResultErr.toString()}.`)
@@ -196,114 +236,90 @@ async function prepareDeploymentDirectory (assetPath, assetMatch) {
   }, 10);
 
   try {
-    info('Preparing deployment directory...');
-
-    await fs.emptyDir(getFullPath(deployDir));
-    await copyPool.start();
-
-    info('Deployment directory created.');
+    spinner.start('Creating deployment directory')
+    await fs.emptyDir(getFullPath(deployDir))
+    await copyPool.start()
+    spinner.succeed('Deployment directory created.')
   } catch (err) {
-    error('Something went wrong...')
+    spinner.fail('Deployment directory could not be created.')
+    error(err)
+  }
+}
+
+async function gzipFiles(filesToGzip) {
+  const filesQueue = [...filesToGzip]
+
+  const gzipPool = new PromisePool(() => {
+    if (filesQueue.length === 0) return null
+
+    const filePath = filesQueue.pop()
+    const outputPath = `${filePath}.gz`
+    const gzip = zlib.createGzip()
+
+    return new Promise((resolve, reject) => {
+      const input = fs.createReadStream(filePath)
+      const output = fs.createWriteStream(outputPath)
+
+      input.pipe(gzip).pipe(output)
+
+      input.on('error', (err) => {
+        reject(err)
+      });
+
+      output.on('error', (err) => {
+        reject(err)
+      });
+
+      output.on('finish', () => {
+        resolve()
+      });
+    }).then(() => fs.rename(outputPath, filePath))
+  }, 10)
+
+  try {
+    spinner.start('Gzipping files')
+    await gzipPool.start()
+    spinner.succeed(`All ${filesToGzip.length} have been gzipped successfully.`)
+  } catch (err) {
+    spinner.fail('Files haven\'t been gzipped properly.')
     error(err)
   }
 }
 
 module.exports = async (options, api) => {
-  info(`Options: ${JSON.stringify(options)}`)
-
-  let awsConfig = {
-    region: options.region,
-    httpOptions: {
-      connectTimeout: 30 * 1000,
-      timeout: 120 * 1000
-    }
+  try {
+    spinner.start('Setting up AWS')
+    S3 = await setupAWS(options.awsProfile, options.region)
+    spinner.succeed('AWS credentials confirmed')
+  } catch (err) {
+    spinner.fail('Setting up AWS failed.')
+    return error(err)
   }
 
-  if (options.awsProfile.toString() !== 'default') {
-    let credentials = new AWS.SharedIniFileCredentials({ profile: options.awsProfile })
-    await credentials.get((err) => {
-      if (err) {
-        error(err.toString())
-      }
-
-      awsConfig.credentials = credentials
-    })
-  }
-
-  AWS.config.update(awsConfig)
-  S3 = new AWS.S3()
-
-  if (await bucketExists(options) === false) {
-    error('Deployment terminated.')
-    return
-  }
+  if (await bucketExists(options) === false) return
 
   options.uploadOptions = { partSize: (5 * 1024 * 1024), queueSize: 4 }
 
-  await prepareDeploymentDirectory(options.assetPath, options.assetMatch);
+  const deployDirPath = getFullPath(deployDir)
+  const filesToDeploy = getAllFiles(deployDirPath)
+  let filesToGzip = []
 
-  const deployDirPath = getFullPath(deployDir);
-  const filesToDeploy = getAllFiles(deployDirPath);
-  let filesToGzip = [];
+  const bucketDeployPath = parseDeployPath(options.deployPath)
+  const uploadTotal = filesToDeploy.length
+  let uploadCount = 0
+
+  const remotePath = options.staticHosting
+    ? `https://s3-${options.region}.amazonaws.com/${options.bucket}/`
+    : `https://${options.bucket}.s3-website-${options.region}.amazonaws.com/`
+
+  await prepareDeploymentDirectory(options.assetPath, options.assetMatch)
 
   if (options.gzip) {
     filesToGzip = getAllFiles(deployDirPath, options.gzipFilePattern)
-      .map(file => file.absolute);
+      .map(file => file.absolute)
 
-    const filesQueue = [...filesToGzip];
-
-    const gzipPool = new PromisePool(() => {
-      if (filesQueue.length === 0) return null
-
-      const filePath = filesQueue.pop();
-      const outputPath = `${filePath}.gz`;
-      const gzip = zlib.createGzip();
-
-      return new Promise((resolve, reject) => {
-        const input = fs.createReadStream(filePath);
-        const output = fs.createWriteStream(outputPath);
-
-        input.pipe(gzip).pipe(output);
-
-        input.on('error', function(err){
-          reject(err);
-        });
-
-        output.on('error', function(err){
-          reject(err);
-        });
-
-        output.on('finish', function(){
-          resolve();
-          info('✔  ' + filePath);
-        });
-      }).then(() => fs.rename(outputPath, filePath));
-    }, 10);
-
-    try {
-      await gzipPool.start();
-      info('All files gzipped properly.');
-    } catch (err) {
-      error('Unexpected error');
-      error(err);
-    }
+    await gzipFiles(filesToGzip)
   }
-
-  let deployPath = options.deployPath
-  // We don't need a leading slash for root deploys on S3.
-  if (deployPath.startsWith('/')) deployPath = deployPath.slice(1, deployPath.length)
-  // But we do need to make sure there's a trailing one on the path.
-  if (!deployPath.endsWith('/') && deployPath.length > 0) deployPath = deployPath + '/'
-
-  let uploadCount = 0
-  let uploadTotal = filesToDeploy.length
-
-  let remotePath = `https://${options.bucket}.s3-website-${options.region}.amazonaws.com/`
-  if (options.staticHosting) {
-    remotePath = `https://s3-${options.region}.amazonaws.com/${options.bucket}/`
-  }
-
-  info(`Deploying ${filesToDeploy.length} assets from ${deployDirPath} to ${remotePath}`)
 
   const uploadPool = new PromisePool(() => {
     if (filesToDeploy.length === 0) return null
@@ -311,7 +327,7 @@ module.exports = async (options, api) => {
     let filename = filesToDeploy.pop().absolute
     let fileStream = fs.readFileSync(filename)
     let fileKey = filename.replace(deployDirPath, '').replace(/\\/g, '/')
-    let fullFileKey = `${deployPath}${fileKey}`
+    let fullFileKey = `${bucketDeployPath}${fileKey}`
 
     return uploadFile({
       fileKey: fullFileKey,
@@ -336,14 +352,15 @@ module.exports = async (options, api) => {
   }, parseInt(options.uploadConcurrency, 10))
 
   try {
+    spinner.start(`Deploying ${filesToDeploy.length} assets from ${deployDirPath} to ${remotePath}`)
     await uploadPool.start()
-    info('Deployment complete.')
+    spinner.succeed(`All ${filesToDeploy.length} assets have been successfully deployed to ${remotePath}`)
 
     if (options.enableCloudfront) {
       invalidateDistribution(options)
     }
   } catch (uploadErr) {
-    error(`Deployment completed with errors.`)
+    spinner.fail('Deployment completed with errors.');
     error(`${uploadErr.toString()}`)
   }
 }

--- a/s3deploy.js
+++ b/s3deploy.js
@@ -138,6 +138,10 @@ async function uploadFile (filename, fileBody, options) {
     ContentType: contentTypeFor(fileKey)
   }
 
+  if (options.cacheControl) {
+    uploadParams.CacheControl = options.cacheControl
+  }
+
   if (pwaSupport) {
     uploadParams.CacheControl = 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0'
   }

--- a/s3deploy.js
+++ b/s3deploy.js
@@ -208,9 +208,7 @@ async function uploadFile ({ fileKey, fileBody, options, gzip }) {
   }
 
   try {
-    spinner.start(`Uploading: ${uploadParams.Key}`);
     await S3.upload(uploadParams, options.uploadOptions).promise()
-    spinner.clear();
   } catch (uploadResultErr) {
     // pass full error with details back to promisePool callback
     throw new Error(`(${options.uploadCount}/${options.uploadTotal}) Upload failed: ${fileKey}. AWS Error: ${uploadResultErr.toString()}.`)
@@ -329,6 +327,8 @@ module.exports = async (options, api) => {
     let fileKey = filename.replace(deployDirPath, '').replace(/\\/g, '/')
     let fullFileKey = `${bucketDeployPath}${fileKey}`
 
+    spinner.start(`Uploading: ${fullFileKey}`);
+
     return uploadFile({
       fileKey: fullFileKey,
       fileBody: fileStream,
@@ -341,11 +341,11 @@ module.exports = async (options, api) => {
       let pwaSupport = options.pwa && options.pwaFiles.split(',').indexOf(fileKey) > -1
       let pwaStr = pwaSupport ? ' with cache disabled for PWA' : ''
 
-      done(`(${uploadCount}/${uploadTotal}) Uploaded ${fullFileKey}${pwaStr}`)
+      spinner.succeed(`(${uploadCount}/${uploadTotal}) Uploaded ${fullFileKey}${pwaStr}`)
       // resolve()
     })
     .catch((e) => {
-      error(`Upload failed: ${fullFileKey}`)
+      spinner.fail(`Upload failed: ${fullFileKey}`)
       error(e.toString())
       // reject(e)
     })

--- a/s3deploy.js
+++ b/s3deploy.js
@@ -1,4 +1,4 @@
-const { info, error } = require('@vue/cli-shared-utils')
+const { info, error, done } = require('@vue/cli-shared-utils')
 const path = require('path')
 const fs = require('fs-extra')
 const mime = require('mime-types')
@@ -341,7 +341,7 @@ module.exports = async (options, api) => {
       let pwaSupport = options.pwa && options.pwaFiles.split(',').indexOf(fileKey) > -1
       let pwaStr = pwaSupport ? ' with cache disabled for PWA' : ''
 
-      info(`(${uploadCount}/${uploadTotal}) Uploaded ${fullFileKey}${pwaStr}`)
+      done(`(${uploadCount}/${uploadTotal}) Uploaded ${fullFileKey}${pwaStr}`)
       // resolve()
     })
     .catch((e) => {
@@ -352,9 +352,9 @@ module.exports = async (options, api) => {
   }, parseInt(options.uploadConcurrency, 10))
 
   try {
-    spinner.start(`Deploying ${filesToDeploy.length} assets from ${deployDirPath} to ${remotePath}`)
+    spinner.start(`Deploying ${uploadTotal} assets from ${deployDirPath} to ${remotePath}`)
     await uploadPool.start()
-    spinner.succeed(`All ${filesToDeploy.length} assets have been successfully deployed to ${remotePath}`)
+    spinner.succeed(`All ${uploadTotal} assets have been successfully deployed to ${remotePath}`)
 
     if (options.enableCloudfront) {
       invalidateDistribution(options)

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,6 +40,11 @@ ajv@^5.1.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -222,7 +227,7 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0:
+chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
@@ -248,10 +253,15 @@ cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
-cli-spinners@^1.0.1:
+cli-spinners@^1.0.1, cli-spinners@^1.1.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-1.3.1.tgz#002c1990912d0d59580c93bd36c056de99e4259a"
   integrity sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==
+
+clone@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
+  integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
 co@^4.6.0:
   version "4.6.0"
@@ -334,6 +344,13 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+
+defaults@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
+  integrity sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=
+  dependencies:
+    clone "^1.0.2"
 
 define-properties@^1.1.2:
   version "1.1.2"
@@ -1004,7 +1021,7 @@ lodash@^4.0.0, lodash@^4.13.1:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
   integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
 
-log-symbols@^2.1.0:
+log-symbols@^2.1.0, log-symbols@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
   integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
@@ -1185,6 +1202,18 @@ ora@^1.3.0:
     cli-cursor "^2.1.0"
     cli-spinners "^1.0.1"
     log-symbols "^2.1.0"
+
+ora@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-3.0.0.tgz#8179e3525b9aafd99242d63cc206fd64732741d0"
+  integrity sha512-LBS97LFe2RV6GJmXBi6OKcETKyklHNMV0xw7BtsVn2MlsgsydyZetSCbCANr+PFLmDyv4KV88nn0eCKza665Mg==
+  dependencies:
+    chalk "^2.3.1"
+    cli-cursor "^2.1.0"
+    cli-spinners "^1.1.0"
+    log-symbols "^2.2.0"
+    strip-ansi "^4.0.0"
+    wcwidth "^1.0.1"
 
 p-finally@^1.0.0:
   version "1.0.0"
@@ -1511,6 +1540,13 @@ string.prototype.padstart@^3.0.0:
     es-abstract "^1.4.3"
     function-bind "^1.0.2"
 
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
+  dependencies:
+    ansi-regex "^3.0.0"
+
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
@@ -1641,6 +1677,13 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+wcwidth@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
+  integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
+  dependencies:
+    defaults "^1.0.3"
 
 which@^1.2.9:
   version "1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -563,6 +563,15 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
+fs-extra@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -627,6 +636,11 @@ globby@^8.0.1:
     ignore "^3.3.5"
     pify "^3.0.0"
     slash "^1.0.0"
+
+graceful-fs@^4.1.2, graceful-fs@^4.1.6:
+  version "4.1.15"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
+  integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
 har-schema@^2.0.0:
   version "2.0.0"
@@ -943,6 +957,13 @@ json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -1570,6 +1591,11 @@ union-value@^1.0.0:
     get-value "^2.0.6"
     is-extendable "^0.1.1"
     set-value "^0.4.3"
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
As mentioned in #50 I'm submitting a PR with `gzip` option. I missed this feature while deploying my recent PWA application.

Additionally I slightly cleaned the code and moved some parts to separate functions, as well as used `ora` package for spinners so that we can turn them into both `success` and `failure` state (with @vue/cli-shared-utils` it's unfortunately not possible at the moment).

It might be good to spread logic across different files and add unit tests, but rather in separate PR - all at once. I didn't want to do revolution here :)

Note, that this PR contains changes from #50 too.
