### PR TITLE
Allow matching files & dirs that start with a dot

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ module.exports = (api, configOptions) => {
 
     options.assetPath = process.env.VUE_APP_S3D_ASSET_PATH || options.assetPath
     options.assetMatch = (process.env.VUE_APP_S3D_ASSET_MATCH || options.assetMatch)
+    options.allowDotMatching = (process.env.VUE_APP_S3D_ALLOW_DOT_MATCHING || options.allowDotMatching)
     options.deployPath = process.env.VUE_APP_S3D_DEPLOY_PATH || options.deployPath
     options.acl = process.env.VUE_APP_S3D_ACL || options.acl
 

--- a/prompts.js
+++ b/prompts.js
@@ -86,6 +86,12 @@ module.exports = [
     default: '**'
   },
   {
+    name: 'allowDotMatching',
+    type: 'confirm',
+    message: 'Should files and directories that start with a dot be also deployed?',
+    default: false
+  },
+  {
     name: 'deployPath',
     type: 'input',
     message: 'Where in the bucket should the files be deployed?',


### PR DESCRIPTION
This PR introduces a small change that would allow users to match files & directories that start with a dot, for example: `.well-known`. Any suggestions are more than welcome.