### PR TITLE
Allow overriding the endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Options are set in `vue.config.js` and overridden on a per-environment basis by 
 ```js
 {
     awsProfile: "Specifies the credentials profile to use. For env vars, omit or set to 'default'. (default: default)",
+    endpoint: "Override the default AWS endpoint with another e.g. DigitalOcean.",
     region: "AWS region for the specified bucket (default: us-east-1)",
     bucket: "The S3 bucket name (required)",
     createBucket: "Create the bucket if it doesn't exist (default: false)",

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ module.exports = (api, configOptions) => {
     }
 
     // Check for environment overrides of the options in vue.config.js.
+    options.endpoint = process.env.VUE_APP_S3D_ENDPOINT || options.endpoint
     options.awsProfile = process.env.VUE_APP_S3D_AWS_PROFILE || options.awsProfile
     options.region = process.env.VUE_APP_S3D_REGION || options.region
     options.bucket = process.env.VUE_APP_S3D_BUCKET || options.bucket

--- a/s3deploy.js
+++ b/s3deploy.js
@@ -33,7 +33,7 @@ async function setupAWS(awsProfile, region, endpoint) {
     }
   }
 
-  if (!endpoint) {
+  if (endpoint) {
     awsConfig.endpoint = new AWS.Endpoint(endpoint)
   }
 

--- a/s3deploy.js
+++ b/s3deploy.js
@@ -24,13 +24,17 @@ function contentTypeFor(filename) {
   return mime.lookup(filename) || 'application/octet-stream'
 }
 
-async function setupAWS(awsProfile, region) {
+async function setupAWS(awsProfile, region, endpoint) {
   const awsConfig = {
     region: region,
     httpOptions: {
       connectTimeout: 30 * 1000,
       timeout: 120 * 1000
     }
+  }
+
+  if (!endpoint) {
+    awsConfig.endpoint = new AWS.Endpoint(endpoint)
   }
 
   if (awsProfile.toString() !== 'default') {
@@ -291,7 +295,7 @@ async function gzipFiles(filesToGzip) {
 module.exports = async (options, api) => {
   try {
     spinner.start('Setting up AWS')
-    S3 = await setupAWS(options.awsProfile, options.region)
+    S3 = await setupAWS(options.awsProfile, options.region, options.endpoint)
     spinner.succeed('AWS credentials confirmed')
   } catch (err) {
     spinner.fail('Setting up AWS failed.')


### PR DESCRIPTION
Hello everyone,

I'm currently using DigitalOcean Spaces. The API is the same as AWS, but obviously has a different endpoint. With these changes a config option `endpoint` is added that overrides the default endpoint by AWS.

If there's anything I can improve, I'd appreciate the feedback. It's my first pull request.