### PR TITLE
Fix module exception on Linux

### DIFF
--- a/configuration.js
+++ b/configuration.js
@@ -5,7 +5,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = exports.VERSION = void 0;
 
-var _snakecase = _interopRequireDefault(require("lodash/snakecase"));
+var _snakecase = _interopRequireDefault(require("lodash/snakeCase"));
 
 var _joi = _interopRequireDefault(require("joi"));
 

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -1,4 +1,4 @@
-import snakeCase from 'lodash/snakecase'
+import snakeCase from 'lodash/snakeCase'
 import Joi from 'joi'
 import { join } from 'path';
 


### PR DESCRIPTION
This only works now because the macOS filesystem is case insensitive.

Here's the error I was getting on my Travis CI system:

```
Error: Cannot find module 'lodash/snakecase'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:582:15)
    at Function.Module._load (internal/modules/cjs/loader.js:508:25)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:22:18)
    at Object.<anonymous> (/home/travis/build/Ibotta/myproject/node_modules/vue-cli-plugin-s3-deploy/config
uration.js:8:41)
    at Module._compile (internal/modules/cjs/loader.js:701:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:712:10)
    at Module.load (internal/modules/cjs/loader.js:600:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:539:12)
    at Function.Module._load (internal/modules/cjs/loader.js:531:3)
```

and here's me in a debugging session, showing the error:

```console
> require('lodash/snakecase')
{ Error: Cannot find module 'lodash/snakecase'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:582:15)
    at Function.Module._load (internal/modules/cjs/loader.js:508:25)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:22:18) code: 'MODULE_NOT_FOUND' }
> travis@travis-job-79da1bf0-db00-478d-93d3-812a59000426:~/build/Ibotta/myproject$ node --version
v10.15.3
travis@travis-job-79da1bf0-db00-478d-93d3-812a59000426:~/build/Ibotta/myproject$ node
> require('lodash/snakeCase')
[Function]
```

Here's the stack overflow post that led me to this solution:

https://stackoverflow.com/a/46922137/808678