### PR TITLE
Update options section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Options are set in `vue.config.js` and overridden on a per-environment basis by 
     staticIndexPage: "Sets the default index file (default: index.html)",
     staticErrorPage: "Sets the default error file (default: error.html)",
     assetPath: "The path to the built assets (default: dist)",
-    assetMatch: "Regex matcher for asset to deploy (default: **)"
+    assetMatch: "Regex matcher for asset to deploy (default: **)",
     deployPath: "Path to deploy the app in the bucket (default: /)",
     acl: "Access control list permissions to apply in S3 (default: public-read)",
     uploadConcurrency: "The number of concurrent uploads to S3 (default: 3)",
@@ -70,7 +70,7 @@ Options are set in `vue.config.js` and overridden on a per-environment basis by 
     cloudfrontId: "The ID of the distribution to invalidate",
     cloudfrontMatchers: "A comma-separated list of paths to invalidate (default: /*)",
     uploadConcurrency: "Number of concurrent uploads (default: 5)",
-    cacheControl: "Sets cache-control metadata for all uploads, overridden for individual files by pwa settings"
+    cacheControl: "Sets cache-control metadata for all uploads, overridden for individual files by pwa settings",
     gzip: "Enables GZIP compression",
     gzipFilePattern: "Pattern for matching files to be gzipped. (By default: '**/*.{js,css,json,ico,map,xml,txt,svg,eot,ttf,woff,woff2}')"
 }

--- a/README.md
+++ b/README.md
@@ -50,29 +50,33 @@ Options
 Options are set in `vue.config.js` and overridden on a per-environment basis by `.env`, `.env.staging`, `.env.production`, etc.
 
 ```js
-{
-    awsProfile: "Specifies the credentials profile to use. For env vars, omit or set to 'default'. (default: default)",
-    endpoint: "Override the default AWS endpoint with another e.g. DigitalOcean.",
-    region: "AWS region for the specified bucket (default: us-east-1)",
-    bucket: "The S3 bucket name (required)",
-    createBucket: "Create the bucket if it doesn't exist (default: false)",
-    staticHosting: "Enable S3 static site hosting (default: false)",
-    staticIndexPage: "Sets the default index file (default: index.html)",
-    staticErrorPage: "Sets the default error file (default: error.html)",
-    assetPath: "The path to the built assets (default: dist)",
-    assetMatch: "Regex matcher for asset to deploy (default: **)",
-    deployPath: "Path to deploy the app in the bucket (default: /)",
-    acl: "Access control list permissions to apply in S3 (default: public-read)",
-    uploadConcurrency: "The number of concurrent uploads to S3 (default: 3)",
-    pwa: "Sets max-age=0 for the PWA-related files specified (default: false)",
-    pwaFiles: "Comma-separated list of files to treat as PWA files",
-    enableCloudfront: "Enables support for Cloudfront distribution invalidation (default: false)",
-    cloudfrontId: "The ID of the distribution to invalidate",
-    cloudfrontMatchers: "A comma-separated list of paths to invalidate (default: /*)",
-    uploadConcurrency: "Number of concurrent uploads (default: 5)",
-    cacheControl: "Sets cache-control metadata for all uploads, overridden for individual files by pwa settings",
-    gzip: "Enables GZIP compression",
-    gzipFilePattern: "Pattern for matching files to be gzipped. (By default: '**/*.{js,css,json,ico,map,xml,txt,svg,eot,ttf,woff,woff2}')"
+module.exports = {
+  pluginOptions: {
+    s3Deploy: {
+      awsProfile: "Specifies the credentials profile to use. For env vars, omit or set to 'default'. (default: default)",
+      endpoint: "Override the default AWS endpoint with another e.g. DigitalOcean.",
+      region: "AWS region for the specified bucket (default: us-east-1)",
+      bucket: "The S3 bucket name (required)",
+      createBucket: "Create the bucket if it doesn't exist (default: false)",
+      staticHosting: "Enable S3 static site hosting (default: false)",
+      staticIndexPage: "Sets the default index file (default: index.html)",
+      staticErrorPage: "Sets the default error file (default: error.html)",
+      assetPath: "The path to the built assets (default: dist)",
+      assetMatch: "Regex matcher for asset to deploy (default: **)",
+      deployPath: "Path to deploy the app in the bucket (default: /)",
+      acl: "Access control list permissions to apply in S3 (default: public-read)",
+      uploadConcurrency: "The number of concurrent uploads to S3 (default: 3)",
+      pwa: "Sets max-age=0 for the PWA-related files specified (default: false)",
+      pwaFiles: "Comma-separated list of files to treat as PWA files",
+      enableCloudfront: "Enables support for Cloudfront distribution invalidation (default: false)",
+      cloudfrontId: "The ID of the distribution to invalidate",
+      cloudfrontMatchers: "A comma-separated list of paths to invalidate (default: /*)",
+      uploadConcurrency: "Number of concurrent uploads (default: 5)",
+      cacheControl: "Sets cache-control metadata for all uploads, overridden for individual files by pwa settings",
+      gzip: "Enables GZIP compression",
+      gzipFilePattern: "Pattern for matching files to be gzipped. (By default: '**/*.{js,css,json,ico,map,xml,txt,svg,eot,ttf,woff,woff2}')"
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
Came across this readme when trying to answer someone asking question regarding this plugin on reddit [over here](https://www.reddit.com/r/vuejs/comments/f49qgk/how_do_i_make_s3_deploy_plugin_to_skip_static/).

In this minor pull request, the **s3Deploy** in particular within pluginOptions should make it clearer for readers to understand how to use the options for this plugin in the **vue.config.js** file. This formatting/style is also used in other plugins like [vue-cli-plugin-i18n](https://github.com/kazupon/vue-cli-plugin-i18n#wrench-configrations), [vue-cli-plugin-ssr](https://vue-cli-plugin-ssr.netlify.com/guide/configuration.html#configuration) and [vue-cli-plugin-apollo](https://vue-cli-plugin-apollo.netlify.com/guide/configuration.html#plugin-options) so it should feel more familiar to developers learning how to use vue cli plugins.