### PR TITLE
Fix bug with returning undefined from method deployPath

### DIFF
--- a/src/deployer.js
+++ b/src/deployer.js
@@ -134,7 +134,7 @@ class Deployer {
   }
 
   deployPath (path) {
-    let fixedPath
+    let fixedPath = path
 
     // We don't need a leading slash for root deploys on S3.
     if (path.startsWith('/')) fixedPath = path.slice(1, path.length)


### PR DESCRIPTION
Config example
```
module.exports = {
  pluginOptions: {
    s3Deploy: {
      ...
      deployPath: 'some-path-without-slash-on-start/',
      ...
    }
  }
}
```

Log
```
 INFO  Connection to S3 created.
 INFO  Deploying 20 assets from <hidden>/dist/ to https://s3-eu-west-2.amazonaws.com/<hidden>/
 INFO  (1/20) Uploaded undefinedjs/chunk-2714bc1b.6fcbdcb9.js
 INFO  (2/20) Uploaded undefinedjs/chunk-2714bc1b.6fcbdcb9.js.map
 INFO  (3/20) Uploaded undefinedjs/app.9b186333.js.map
 INFO  (4/20) Uploaded undefinedjs/chunk-vendors.81f86ec2.js
 INFO  (5/20) Uploaded undefinedjs/chunk-vendors.81f86ec2.js.map
 INFO  (6/20) Uploaded undefinedjs/app.9b186333.js
 ...
 INFO  (20/20) Uploaded undefinedindex.html
 INFO  Deployment complete.

```