### PR TITLE
Fix bug with dual deploy path

### DIFF
--- a/src/deployer.js
+++ b/src/deployer.js
@@ -120,7 +120,7 @@ class Deployer {
     }
 
     try {
-      return this.bucket.uploadFile(fullFileKey, fileStream, {
+      return this.bucket.uploadFile(fileKey, fileStream, {
         pwa: pwaSupportForFile,
         gzip: gzip
       }).then(() => {


### PR DESCRIPTION
Config example
```
module.exports = {
  pluginOptions: {
    s3Deploy: {
      ...
      deployPath: '/some-path/',
      ...
    }
  }
}
```
All files uploaded to path **/some-path/some-path/...**