### PR TITLE
Permit ignore some files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ s3-deploy for vue-cli
 
 CALL FOR CONTRIBUTORS
 ===
-If you'd like to participate in the development and maintenance of this plugin, please open a PR or an issue. Help is welcome. 
+If you'd like to participate in the development and maintenance of this plugin, please open a PR or an issue. Help is welcome.
 Thanks to all who have contributed so far!
 
 **NOTE:** This branch refers to version 4.0.0 and above. See the [3.0.0 branch](https://github.com/multiplegeorges/vue-cli-plugin-s3-deploy/tree/3.0.0) for the previous version.
@@ -65,6 +65,7 @@ module.exports = {
       staticErrorPage: "Sets the default error file (default: error.html)",
       assetPath: "The path to the built assets (default: dist)",
       assetMatch: "Regex matcher for asset to deploy (default: **)",
+      ignoreMatch: "Regex matcher for ignore some files to deploy (default: '')",
       deployPath: "Path to deploy the app in the bucket (default: /)",
       acl: "Access control list permissions to apply in S3 (default: public-read)",
       pwa: "Sets max-age=0 for the PWA-related files specified (default: false)",

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -34,6 +34,7 @@ class Configuration {
       staticWebsiteConfiguration: Joi.object(),
       assetPath: Joi.string().default('dist'),
       assetMatch: Joi.string().default('**'),
+      ignoreMatch: Joi.string().default(''),
       deployPath: Joi.string().default('/'),
       acl: Joi.string().default('public-read'),
       pwa: Joi.boolean().default(false),

--- a/src/deployer.js
+++ b/src/deployer.js
@@ -30,7 +30,7 @@ class Deployer {
     config.deployPath = this.deployPath(config.options.deployPath)
 
     config.fileList = globby.sync(
-      config.options.assetMatch,
+      [config.options.assetMatch, config.options.ignoreMatch],
       { cwd: config.fullAssetPath }
     ).map(file => path.join(config.fullAssetPath, file))
 

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -98,6 +98,12 @@ module.exports = [
     default: '**'
   },
   {
+    name: 'ignoreMatch',
+    type: 'input',
+    message: 'Which files should be ignored?',
+    default: ''
+  },
+  {
     name: 'deployPath',
     type: 'input',
     message: 'Where in the bucket should the files be deployed?',


### PR DESCRIPTION
## Motivation
In my current project we use [rollbar-sourcemap-webpack-plugin](https://www.npmjs.com/package/rollbar-sourcemap-webpack-plugin), this plugin generate and upload .js.map files on build process. All .js.map files is recommended to no be public:
![image](https://user-images.githubusercontent.com/1077589/79670999-44107800-819d-11ea-888a-d9db5e87bca7.png)

I believe this is a common pattern and other projects should have the same problem

## Workaround
For now before of `npm run deploy` we running `rm -R dist/js/*.map` but I believe this should be the responsibility of the deploy tool.

## Solution
Add another optional config (`ignoreMatch`) to permit ignore some files based on Globbing patterns.
I think this config should be as default something like `!**/*.map`, but to not generate break change, suggest the default as an empty string for now.