### PR TITLE
Set cloudfrontMatchers default to match the docs

### DIFF
--- a/src/configuration.js
+++ b/src/configuration.js
@@ -40,7 +40,7 @@ class Configuration {
       pwaFiles: Joi.string().default('index.html,service-worker.js,manifest.json'),
       enableCloudfront: Joi.boolean().default(false),
       cloudfrontId: Joi.string(),
-      cloudfrontMatchers: Joi.string().default('/index.html,/service-worker.js,/manifest.json'),
+      cloudfrontMatchers: Joi.string().default('/*'),
       registry: Joi.any(),
       gzip: Joi.boolean().default(false),
       gzipFilePattern: Joi.string().default('**/*.{js,css,json,ico,map,xml,txt,svg,eot,ttf,woff,woff2}'),


### PR DESCRIPTION
In the README, it states that the `cloudfrontMatchers` configuration variable defaults to `/*`. Reading that, I left that variable out but then realized in AWS that it was _actually_ behaving differently.

This PR sets the default for this key to match the docs.