### PR TITLE
Added info to README about how to clean up old files after deploying

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ The AWS SDK will pick up the specified credentials from your `~/.aws/credentials
 
 To specify credentials other than `default` in `~/.aws/credentials`, re-run `vue invoke s3-deploy` and select a different profile.
 
+Cleanup
+---
+
+If your build process appends hashes to the files it generates, you may find that files with old hashes build up in your S3 bucket. Consider using this plugin to tag these old files so that S3 can expire them after a set number of days: https://github.com/euan-forrester/vue-cli-plugin-s3-deploy-cleanup
 
 Changelog
 ---


### PR DESCRIPTION
I wrote a companion plugin that helps to cleanup the S3 bucket after deploying by tagging all files in the deployment directory in S3 that are not on the local machine. Thus, any files with old hashes will be tagged and can be expired in a set number of days using S3 lifecycle rules.

This helps prevent the bucket from becoming filled with old files, making it difficult to tell which is the most current version of a given file.

I added a link to this new plugin to the README -- please let me know your thoughts!