### PR TITLE
fix: check file pattern correctly when gzip

### DIFF
--- a/src/deployer.js
+++ b/src/deployer.js
@@ -113,7 +113,8 @@ class Deployer {
     let fileKey = filename.replace(this.config.fullAssetPath, '').replace(/\\/g, '/')
     let fullFileKey = (`${this.config.deployPath}${fileKey}`).replace(/\/\//g, '/');
     let pwaSupportForFile = this.config.options.pwa && this.config.options.pwaFiles.split(',').indexOf(fileKey) > -1
-    let gzip = this.config.options.gzip && globby.sync(this.config.options.gzipFilePattern, { cwd: this.config.fullAssetPath })
+    let gzipMatches = globby.sync(this.config.options.gzipFilePattern, { cwd: this.config.fullAssetPath })
+    let gzip = this.config.options.gzip && gzipMatches.indexOf(fileKey) !== -1
 
     if (gzip) {
       fileStream = zlib.gzipSync(fileStream, { level: 9 })


### PR DESCRIPTION
There is a bug with gzip file pattern due to `globby.sync` returns array of file location instead of boolean value