### PR TITLE
Update configuration.js VERSION

### DIFF
--- a/src/configuration.js
+++ b/src/configuration.js
@@ -2,7 +2,7 @@ import { snakeCase } from 'lodash';
 import Joi from 'joi';
 import { join } from 'path';
 
-const VERSION = '4.0.0-rc3'
+const VERSION = '4.0.0-rc4'
 
 class Configuration {
   constructor (options) {


### PR DESCRIPTION
The version number was not updated to match npm, which causes runtime errors. This PR updates them to match.