### PR TITLE
Changing build output to dist dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "AWS_ACCESS_KEY_ID=access-key AWS_SECRET_ACCESS_KEY=secret-key jest --verbose src/test",
     "watch-test": "AWS_ACCESS_KEY_ID=access-key AWS_SECRET_ACCESS_KEY=secret-key jest --watch src/test",
-    "build": "rm -rf ./dist && babel src/*.js --presets @babel/preset-env --out-dir ./",
+    "build": "rm -rf ./dist && babel src/*.js --presets @babel/preset-env --out-dir ./dist",
     "build-watch": "babel src/*.js --watch --presets @babel/preset-env --out-dir ./",
     "prepublish": "yarn build"
   },


### PR DESCRIPTION
The output files is written in main dir when the project is builted. Changed to ./dist file